### PR TITLE
Fix pep8 linting warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ jobs:
         environment:
         - PG_HOST=localhost
         - PG_USER=postgres
+      # For the database service
       - image: postgres:9.5
         environment:
         - POSTGRES_USER=postgres
@@ -38,7 +39,13 @@ jobs:
           paths:
             - ./venv
           key: v1-dependencies-{{ checksum "requirements.txt" }}
-
+      - run:
+          name: Pycodestyle (formerly pep8) check
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            # Exclude check on venv files that include pip-installed packages
+            pycodestyle --exclude='venv/**' .
       - run:
           name: Test App
           command: |

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -20,7 +20,6 @@ def create_app(config_name):
 
     db.init_app(app)
 
-
     # import the organization blueprint and register it on the app
     from .organization import org_blueprint
     from .programs import program_blueprint

--- a/app/locations.py
+++ b/app/locations.py
@@ -6,6 +6,7 @@ from app.models import Location
 
 location_blueprint = Blueprint('location', __name__)
 
+
 class LocationView(MethodView):
     """
     This class handles API requests for the location resource.
@@ -38,9 +39,8 @@ class LocationView(MethodView):
                 abort(404)
 
         except Exception as e:
-            response = { "message": str(e) }
+            response = {"message": str(e)}
             return make_response(jsonify(response)), 400
-
 
     def get(self, organization_id, location_id):
         """
@@ -57,7 +57,7 @@ class LocationView(MethodView):
                     return make_response(jsonify(response)), 200
 
                 except Exception as e:
-                    response = { "message": str(e) }
+                    response = {"message": str(e)}
                     return make_response(jsonify(response)), 400
         else:
             # handle get all
@@ -89,7 +89,7 @@ class LocationView(MethodView):
                 return make_response(jsonify(response)), 200
 
             except Exception as e:
-                response = {"message": str(e) }
+                response = {"message": str(e)}
                 return make_response(jsonify(response)), 400
         else:
             abort(404)
@@ -107,7 +107,7 @@ class LocationView(MethodView):
                     return make_response(jsonify({})), 202
 
                 except Exception as e:
-                    res = { "message": str(e) }
+                    res = {"message": str(e)}
                     return make_response(jsonify(res)), 400
         else:
             abort(404)
@@ -126,5 +126,3 @@ location_blueprint.add_url_rule(
     '/api/organizations/<int:organization_id>/locations/<int:location_id>',
     view_func=location_view,
     methods=['GET', 'PUT', 'DELETE'])
-
-

--- a/app/models.py
+++ b/app/models.py
@@ -38,7 +38,6 @@ class Organization(db.Model, BaseMixin):
     service = relationship("Service", backref="organization",
                            passive_deletes=True)
 
-
     def __init__(self, name, description, email=None, url=None,
                  year_incorporated=None):
         self.name = name
@@ -121,7 +120,6 @@ class Service(db.Model, BaseMixin):
     status = db.Column(db.String(10), nullable=True)
     fees = db.Column(db.String(10), nullable=True)
 
-
     def __init__(self, name, organization_id, program_id=None, status=None,
                  fees=None, email=None, url=None):
         """Initialize the service with its fields."""
@@ -163,13 +161,13 @@ class Location(db.Model, BaseMixin):
     organization_id = db.Column(db.Integer, db.ForeignKey(Organization.id,
                                                           ondelete='CASCADE'))
     alternate_name = db.Column(db.String(100), nullable=True)
-    description = db.Column(db.String(100), nullable = True)
+    description = db.Column(db.String(100), nullable=True)
     transportation = db.Column(db.String(256), nullable=True)
     latitude = db.Column(db.Integer, nullable=True)
     longitude = db.Column(db.Integer, nullable=True)
 
     address = relationship("PhysicalAddress", backref="location",
-                            passive_deletes=True)
+                           passive_deletes=True)
 
     def __init__(self, name, organization_id, alternate_name=None,
                  description=None, transportation=None, latitude=None,
@@ -187,7 +185,6 @@ class Location(db.Model, BaseMixin):
         """Save a location when creating a new one."""
         db.session.add(self)
         db.session.commit()
-
 
     @staticmethod
     def get_all(organization_id):
@@ -229,7 +226,6 @@ class ServiceLocation(db.Model, BaseMixin):
         return "{}".format(self.id)
 
 
-
 class PhysicalAddress(db.Model, BaseMixin):
     """This class defines a representation of the physical address model."""
 
@@ -242,7 +238,7 @@ class PhysicalAddress(db.Model, BaseMixin):
     city = db.Column(db.String(100), nullable=False)
     state = db.Column(db.String(20), nullable=False)
     postal_code = db.Column(db.String(20), nullable=False)
-    country = db.Column(db.String(2), nullable=False) # Two-letter country code
+    country = db.Column(db.String(2), nullable=False)  # 2-letter country code
 
     def save(self):
         """Save the instance of the physical address."""
@@ -263,7 +259,3 @@ class PhysicalAddress(db.Model, BaseMixin):
         """Return a representation of the model instance."""
         return "{}: {}, {} {}".format(self.id, self.address, self.city,
                                       self.postal_code)
-
-
-
-

--- a/app/organization.py
+++ b/app/organization.py
@@ -58,7 +58,8 @@ class OrganizationView(MethodView):
 
         else:
             # Expose a single organization
-            organization = Organization.query.filter_by(id=organization_id).first()
+            organization = Organization.query.filter_by(
+                id=organization_id).first()
             if not organization:
                 abort(404)
             else:
@@ -70,7 +71,6 @@ class OrganizationView(MethodView):
                         "message": str(e)
                     }
                     return make_response(jsonify(response)), 400
-
 
     def put(self, organization_id):
         """Update an organization given its id."""
@@ -136,7 +136,4 @@ org_blueprint.add_url_rule(
 
 org_blueprint.add_url_rule(
     '/api/organizations/', view_func=organization_view,
-    methods=['POST',])
-
-
-
+    methods=['POST', ])

--- a/app/physical_address.py
+++ b/app/physical_address.py
@@ -41,7 +41,7 @@ class PhysicalAddressView(MethodView):
                     else:
                         abort(404)
         except Exception as e:
-            response = { "message": str(e) }
+            response = {"message": str(e)}
             return make_response(jsonify(response)), 400
 
     def get(self, organization_id, location_id, address_id):
@@ -64,14 +64,13 @@ class PhysicalAddressView(MethodView):
                     res = address.serialize()
                     return make_response(jsonify(res)), 200
                 except Exception as e:
-                    res = { "message": str(e) }
+                    res = {"message": str(e)}
                     return make_response(jsonify(res)), 400
         else:
             # get all addresses
             addresses = PhysicalAddress.get_all(location_id)
             res = [address.serialize() for address in addresses]
             return make_response(jsonify(res)), 200
-
 
     def put(self, organization_id, location_id, address_id):
         """Update an address and return it as json."""
@@ -102,7 +101,7 @@ class PhysicalAddressView(MethodView):
                 res = address.serialize()
                 return make_response(jsonify(res)), 200
             except Exception as e:
-                res = { "message": str(e) }
+                res = {"message": str(e)}
                 return make_response(jsonify(res)), 400
         else:
             abort(404)
@@ -127,7 +126,7 @@ class PhysicalAddressView(MethodView):
                     address.delete()
                     return make_response(jsonify({})), 202
                 except Exception as e:
-                    res = { "message": str(e) }
+                    res = {"message": str(e)}
                     return make_response(jsonify(res)), 500
         else:
             abort(404)
@@ -135,15 +134,16 @@ class PhysicalAddressView(MethodView):
 
 address_view = PhysicalAddressView.as_view('address_view')
 address_blueprint.add_url_rule(
-    '/api/organizations/<int:organization_id>/locations/<int:location_id>/addresses/',
+    '/api/organizations/<int:organization_id>/locations/' +
+    '<int:location_id>/addresses/',
     view_func=address_view, methods=['POST'])
 address_blueprint.add_url_rule(
-    '/api/organizations/<int:organization_id>/locations/<int:location_id>/addresses/',
+    '/api/organizations/<int:organization_id>/locations/' +
+    '<int:location_id>/addresses/',
     view_func=address_view, defaults={'address_id': None},
     methods=['GET'])
 address_blueprint.add_url_rule(
-    '/api/organizations/<int:organization_id>/locations/<int:location_id>/addresses/<int:address_id>',
+    '/api/organizations/<int:organization_id>/locations/' +
+    '<int:location_id>/addresses/<int:address_id>',
     view_func=address_view,
     methods=['GET', 'PUT', 'DELETE'])
-
-

--- a/app/programs.py
+++ b/app/programs.py
@@ -39,9 +39,8 @@ class ProgramView(MethodView):
                 response = program.serialize()
                 return make_response(jsonify(response)), 201
             except Exception as e:
-                response = { "message": str(e) }
+                response = {"message": str(e)}
                 return make_response(jsonify(response)), 400
-
 
     def get(self, organization_id, program_id):
         """
@@ -63,7 +62,7 @@ class ProgramView(MethodView):
                     return make_response(jsonify(response)), 200
 
                 except Exception as e:
-                    response = { "message": str(e) }
+                    response = {"message": str(e)}
                     return make_response(jsonify(response)), 400
         else:
             # handle get all
@@ -108,7 +107,7 @@ class ProgramView(MethodView):
             except Exception as e:
                 if not program:
                     abort(404)
-                response = { "message": str(e) }
+                response = {"message": str(e)}
                 return make_response(jsonify(response)), 400
         else:
             abort(404)
@@ -130,9 +129,8 @@ class ProgramView(MethodView):
                     return make_response(jsonify({})), 202
 
                 except Exception as e:
-                    response = { "message": str(e) }
+                    response = {"message": str(e)}
                     return make_response(jsonify(response)), 400
-
 
 
 program_view = ProgramView.as_view('program_view')

--- a/app/services.py
+++ b/app/services.py
@@ -56,7 +56,7 @@ class ServiceView(MethodView):
                         # the org is none-existent - return 404 not found
                         abort(404)
             except Exception as e:
-                response = { "message": str(e) }
+                response = {"message": str(e)}
                 return make_response(jsonify(response)), 400
         else:
             # Create the service without the program ID (the service is on its
@@ -108,7 +108,7 @@ class ServiceView(MethodView):
                             response = service.serialize()
                             return make_response(jsonify(response)), 200
                         except Exception as e:
-                            response = { "message": str(e) }
+                            response = {"message": str(e)}
                             return make_response(jsonify(response)), 400
         else:
             # handle get all
@@ -159,7 +159,7 @@ class ServiceView(MethodView):
                 return make_response(jsonify(response)), 200
 
             except Exception as e:
-                response = { "message": str(e) }
+                response = {"message": str(e)}
                 return make_response(jsonify(response)), 400
         else:
             abort(404)
@@ -178,7 +178,7 @@ class ServiceView(MethodView):
                 service.delete()
                 return make_response(jsonify({})), 202
             except Exception as e:
-                response = { "message": str(e) }
+                response = {"message": str(e)}
                 return make_response(jsonify(response)), 400
 
         if service_id is not None:
@@ -189,11 +189,10 @@ class ServiceView(MethodView):
                 return make_response(jsonify({})), 202
 
             except Exception as e:
-                response = { "message": str(e) }
+                response = {"message": str(e)}
                 return make_response(jsonify(response)), 400
         else:
             abort(404)
-
 
 
 service_view = ServiceView.as_view('service_view')
@@ -205,12 +204,14 @@ service_blueprint.add_url_rule(
     view_func=service_view, defaults={'program_id': None},
     methods=['GET', 'PUT', 'DELETE'])
 service_blueprint.add_url_rule(
-    '/api/organizations/<int:organization_id>/programs/<int:program_id>/services/',
+    '/api/organizations/<int:organization_id>/programs/' +
+    '<int:program_id>/services/',
     view_func=service_view, methods=['POST'])
 service_blueprint.add_url_rule(
-    '/api/organizations/<int:organization_id>/programs/<int:program_id>/services/',
+    '/api/organizations/<int:organization_id>/programs/' +
+    '<int:program_id>/services/',
     view_func=service_view, defaults={'service_id': None}, methods=['GET'])
 service_blueprint.add_url_rule(
-    '/api/organizations/<int:organization_id>/programs/<int:program_id>/services/<int:service_id>',
+    '/api/organizations/<int:organization_id>/programs/' +
+    '<int:program_id>/services/<int:service_id>',
     view_func=service_view, methods=['GET', 'PUT', 'DELETE'])
-

--- a/instance/config.py
+++ b/instance/config.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 
+
 class Config(object):
     """Parent configuration class."""
     DEBUG = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ Flask-SQLAlchemy==2.2
 jwt==0.5.2
 psycopg2==2.7.3.1
 Flask-Script==2.0.6
+pycodestyle

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -70,7 +70,7 @@ class ServiceModelTestCase(BaseTestCase):
 
     def test_service_instance_creation(self):
         """Test that a given service under an org can be created."""
-        org_data= {
+        org_data = {
             "name": "ABC",
             "description": "A big org"
         }
@@ -167,4 +167,3 @@ class PhysicalAddressModelTestCase(BaseTestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -50,7 +50,6 @@ class BaseTestCase(unittest.TestCase):
             os.unlink(self.app.config.get('DATABASE'))
 
 
-
 class OrganizationViewTestCase(BaseTestCase):
     """This class represents the Organization view test case."""
 
@@ -104,7 +103,6 @@ class OrganizationViewTestCase(BaseTestCase):
         self.assertEqual(results_length, 1)
         self.assertIn("BHive", str(rv.data))
 
-
     def test_view_can_update_organization(self):
         """Test that view handle a PUT request to make a change on the org."""
         res = self.client().post('/api/organizations/', data=self.org_data)
@@ -114,8 +112,8 @@ class OrganizationViewTestCase(BaseTestCase):
         new_data = {
             "name": "BrightHive"
         }
-        response = self.client().put('/api/organizations/{}'.format(results['id']),
-                                     data=new_data)
+        response = self.client().put(
+            '/api/organizations/{}'.format(results['id']), data=new_data)
         self.assertEqual(response.status_code, 200)
         self.assertIn("BrightHive", str(response.data))
 
@@ -124,7 +122,8 @@ class OrganizationViewTestCase(BaseTestCase):
         res = self.client().post('/api/organizations/', data=self.org_data)
         self.assertEqual(res.status_code, 201)
         results = json.loads(res.data.decode())
-        response = self.client().delete('/api/organizations/{}'.format(results['id']))
+        response = self.client().delete(
+            '/api/organizations/{}'.format(results['id']))
         self.assertEqual(response.status_code, 202)
 
     def test_view_returns_404_for_nonexistent_orgs(self):
@@ -134,7 +133,7 @@ class OrganizationViewTestCase(BaseTestCase):
         self.assertEqual(res.status_code, 404)
         # test for a PUT request
         put_response = self.client().put('/api/organizations/100/',
-                                data={"name":"Changed"})
+                                         data={"name": "Changed"})
         self.assertEqual(put_response.status_code, 404)
 
         # test for DELETE request
@@ -157,8 +156,9 @@ class ProgramViewTestCase(BaseTestCase):
         org_id = json.loads(org_res.data.decode())['id']
         # then, create the program under the org
         self.program_data['organization_id'] = org_id
-        res = self.client().post('/api/organizations/{}/programs/'.format(org_id),
-                           data=self.program_data)
+        res = self.client().post(
+            '/api/organizations/{}/programs/'.format(org_id),
+            data=self.program_data)
         self.assertEqual(res.status_code, 201)
         self.assertIn("Sample Program", str(res.data))
 
@@ -185,7 +185,8 @@ class ProgramViewTestCase(BaseTestCase):
         self.assertEqual(prog_res1.status_code, 201)
 
         # finally, get all
-        res = self.client().get('/api/organizations/{}/programs/'.format(org_id))
+        res = self.client().get(
+            '/api/organizations/{}/programs/'.format(org_id))
         self.assertEqual(res.status_code, 200)
         # self.assertIn("Another Program", str(res.data))
         self.assertIn("Sample Program", str(res.data))
@@ -219,7 +220,6 @@ class ProgramViewTestCase(BaseTestCase):
         results_length = len(results_data)
         self.assertEqual(results_length, 2)
         self.assertIn("Computer", str(rv.data))
-
 
     def test_view_can_get_program_by_id(self):
         """Test that the view can handle a GET(single) program by id."""
@@ -288,8 +288,9 @@ class ProgramViewTestCase(BaseTestCase):
         res = self.client().get('/api/organizations/100/programs/100')
         self.assertEqual(res.status_code, 404)
         # test for a PUT request
-        put_response = self.client().put('/api/organizations/100/programs/100/',
-                                data={"name":"Changed"})
+        put_response = self.client().put(
+            '/api/organizations/100/programs/100/',
+            data={"name": "Changed"})
         self.assertEqual(put_response.status_code, 404)
 
         # test for DELETE request
@@ -309,8 +310,8 @@ class ServiceViewTestCase(BaseTestCase):
 
     def create_program(self):
         self.program_data = {
-        "name": "Program",
-        "organization_id": 1
+            "name": "Program",
+            "organization_id": 1
         }
         return self.client().post('/api/organizations/1/programs/',
                                   data=self.program_data)
@@ -372,7 +373,7 @@ class ServiceViewTestCase(BaseTestCase):
         not placed under a program."""
         self.create_org()
         service_with_no_prog_id = {
-             "name": "Service",
+            "name": "Service",
             "organization_id": 1,
             "email": "service@mail.com",
             "url": "service.com",
@@ -385,7 +386,7 @@ class ServiceViewTestCase(BaseTestCase):
         self.assertEqual(service.status_code, 201)
         # update the service
         rv = self.client().put('/api/organizations/1/services/1',
-                               data={ "name": "Updated Service"})
+                               data={"name": "Updated Service"})
         self.assertEqual(rv.status_code, 200)
         self.assertIn("Updated Service", str(rv.data))
 
@@ -458,7 +459,6 @@ class ServiceViewTestCase(BaseTestCase):
         self.assertEqual(results_length, 2)
         self.assertIn("Programming", str(rv.data))
 
-
     def test_view_can_get_all_services(self):
         """Test that the view can handle GET request for all existing
         services.
@@ -509,15 +509,16 @@ class ServiceViewTestCase(BaseTestCase):
             '/api/organizations/1/programs/1/services/1')
         self.assertEqual(res.status_code, 202)
         self.assertNotIn("Service", str(res.data))
-         # check to see if it's deleted
-        response = self.client().get('/api/organizations/1/programs/1/services/1')
+        # check to see if it's deleted
+        response = self.client().get(
+            '/api/organizations/1/programs/1/services/1')
         self.assertEqual(response.status_code, 404)
-
 
     def test_view_returns_404_for_nonexistent_orgs(self):
         """Test that the view returns a 404 if the program does not exist."""
         # test for a GET request
-        res = self.client().get('/api/organizations/100/programs/100/services/7')
+        res = self.client().get(
+            '/api/organizations/100/programs/100/services/7')
         self.assertEqual(res.status_code, 404)
         # test for a PUT request
         put_response = self.client().put(
@@ -549,7 +550,7 @@ class LocationViewTestCase(BaseTestCase):
         self.create_org()
 
         res = self.client().post('/api/organizations/1/locations/',
-                           data=self.location_data)
+                                 data=self.location_data)
         self.assertEqual(res.status_code, 201)
         self.assertIn("Chicago", str(res.data))
 
@@ -558,7 +559,7 @@ class LocationViewTestCase(BaseTestCase):
 
         self.create_org()
 
-        #create the location
+        # create the location
         self.client().post('/api/organizations/1/locations/',
                            data=self.location_data)
         # get the location using its id
@@ -639,23 +640,26 @@ class PhysicalAddressViewTestCase(BaseTestCase):
                                   data=self.location_data)
 
     def test_view_can_create_address(self):
-        """Test view handles a POST request to create a physical address entry."""
+        """
+        Test view handles a POST request to create a physical address entry."""
 
         self.create_org()
         self.create_location()
         # create the physical address
         res = self.client().post('/api/organizations/1/locations/1/addresses/',
-                           data=self.address_data)
+                                 data=self.address_data)
         self.assertEqual(res.status_code, 201)
         self.assertIn("Chicago", str(res.data))
 
     def test_view_can_get_an_address(self):
-        """Test view handles a GET (one) request for a physical address correctly."""
+        """
+        Test view handles a GET (one) request for a physical address correctly.
+        """
 
         self.create_org()
         self.create_location()
 
-        #create the address
+        # create the address
         res = self.client().post('/api/organizations/1/locations/1/addresses/',
                                  data=self.address_data)
 
@@ -665,7 +669,9 @@ class PhysicalAddressViewTestCase(BaseTestCase):
         self.assertIn("Chicago", str(res.data))
 
     def test_view_can_get_all_addresses(self):
-        """Test view handles a GET(all) physical address request for a given location."""
+        """
+        Test view handles a GET(all) physical address request
+        for a given location."""
 
         self.create_org()
         self.create_location()
@@ -704,7 +710,8 @@ class PhysicalAddressViewTestCase(BaseTestCase):
         self.client().post('/api/organizations/1/locations/1/addresses/',
                            data=self.address_data)
         # delete the address
-        res = self.client().delete('/api/organizations/1/locations/1/addresses/1')
+        res = self.client().delete(
+            '/api/organizations/1/locations/1/addresses/1')
         self.assertEqual(res.status_code, 202)
         self.assertNotIn("Chicago", str(res.data))
         self.assertEqual({}, json.loads(res.data.decode()))


### PR DESCRIPTION
#### What does this PR do?
- Pip installs `pycodestyle` (previously pep8)
- Fixes linting issues
- Adds this test step to circleCI
#### Description of Task to be completed?
- Add `pycodestyle` to requirements.txt
- Update files with linting warnings
- Add test step to `.circleci/config.yml`
#### How should this be manually tested?
Run pycodestyle excluding checks on `venv` and `migrations` directories by running:
`pycodestyle --exclude='venv/**, migrations/**' .`